### PR TITLE
docs: modding: fix typo in custom bootloader doc

### DIFF
--- a/docs/modding/custom-bootloader.mdx
+++ b/docs/modding/custom-bootloader.mdx
@@ -50,7 +50,7 @@ In addition, it extends the functionality by adding new options for customizing 
 ## Features
 - Blocks ```fastboot flash preloader```
 - Removes orange state
-- Spoofes verified state to green
+- Spoofs verified state to green
 - Block ```fastboot flashing lock```
 - Adds ```fastboot oem help```
 - Adds ```fastboot oem hexdump```


### PR DESCRIPTION
"Spoofes" is not a real world, "spoofs" is the one